### PR TITLE
build: add Dockerfile and .dockerignore for containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# 忽略虚拟环境
+.venv/
+
+# 忽略版本控制文件
+.git/
+.gitignore
+.python-version
+
+# 忽略构建产物
+*.pyc
+__pycache__/
+
+# 忽略IDE配置文件
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# 忽略日志文件
+*.log
+logs/
+
+# 忽略敏感信息文件
+.env
+*.env
+
+# 忽略临时文件
+*.tmp
+*.temp
+
+# 忽略Docker构建过程中不需要的文件
+docker-compose.yml
+*.Dockerfile
+
+# 保留应用运行所需的所有文件
+# default/ 文件夹包含默认配置和背景图片，需要保留
+# templates/ 文件夹包含Flask模板，需要保留
+# config.json 会在应用启动时自动创建或从默认配置复制，不需要忽略
+# background.jpg 会在应用启动时自动创建或从默认配置复制，不需要忽略

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+ENV TZ=Asia/Shanghai
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+ENTRYPOINT ["python", "app.py"]


### PR DESCRIPTION
添加`Dockerfile`以构建Docker镜像。
可使用`docker build -t home-page:latest .`构建。
使用以下代码启动容器 (须在工作目录添加`config.json`、`background.jpg`和`Introduction.md`)
```bash
docker run --name home-page \
  -p 5000:5000 \
  -v ./config.json:/app/config.json \
  -v ./background.jpg:/app/background.jpg \
  -v ./Introduction.md:/app/Introduction.md \
  home-page:latest
```
如果可以，可以考虑推送到Docker Hub。