### PR TITLE
feat: 改进Markdown渲染和前端样式

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -1,24 +1,24 @@
-# 个人主页
+# Personal Home Page
 
-欢迎来到我的个人主页！这里是我展示自己的空间。
+Welcome to my personal home page! This is my space to showcase myself.
 
-## 关于我
+## About Me
 
-我是一名热爱编程的开发者，喜欢探索新技术和解决各种有趣的问题。
+I'm a developer passionate about coding and exploring new technologies. I enjoy solving interesting problems and building great projects.
 
-## 技术栈
+## Tech Stack
 
 - Python
 - JavaScript
 - HTML/CSS
-- Flask
-- Vue.js
+- TypeScript
 - React
+- Node.js
 
-## 项目展示
+## Projects
 
-在这里你可以查看我在 GitHub 上的最新项目和贡献。
+Here you can view my latest projects and contributions on GitHub.
 
-## 联系我
+## Contact
 
-如果你对我的项目感兴趣或者有任何问题，可以通过 GitHub 联系我。
+If you're interested in my projects or have any questions, feel free to contact me through GitHub.

--- a/app.py
+++ b/app.py
@@ -593,8 +593,17 @@ def get_readme_content(username):
         
         if readme_response.status_code == 200:
             print("成功获取main分支的README")
-            # 将 Markdown 转换为 HTML
-            return markdown.markdown(readme_response.text)
+            # 将 Markdown 转换为 HTML 使用扩展
+            return markdown.markdown(
+                readme_response.text,
+                extensions=['extra', 'codehilite', 'toc', 'tables', 'md_in_html'],
+                extension_configs={
+                    'codehilite': {
+                        'css_class': 'highlight',
+                        'linenums': False
+                    }
+                }
+            )
         
         # 尝试其他分支（master）
         readme_url_master = f'https://raw.githubusercontent.com/{username}/{username}/master/README.md'
@@ -604,7 +613,16 @@ def get_readme_content(username):
         
         if readme_response.status_code == 200:
             print("成功获取master分支的README")
-            return markdown.markdown(readme_response.text)
+            return markdown.markdown(
+                readme_response.text,
+                extensions=['extra', 'codehilite', 'toc', 'tables', 'md_in_html'],
+                extension_configs={
+                    'codehilite': {
+                        'css_class': 'highlight',
+                        'linenums': False
+                    }
+                }
+            )
         
         print(f"GitHub README获取失败，状态码: {readme_response.status_code}")
     except Exception as e:
@@ -620,7 +638,18 @@ def get_local_readme():
         introduction_file = config.get('introduction_file', 'Introduction.md')
         if os.path.exists(introduction_file):
             with open(introduction_file, 'r', encoding='utf-8') as f:
-                return markdown.markdown(f.read())
+                # 使用多个扩展来增强 Markdown 转换
+                md_text = f.read()
+                return markdown.markdown(
+                    md_text,
+                    extensions=['extra', 'codehilite', 'toc', 'tables', 'md_in_html'],
+                    extension_configs={
+                        'codehilite': {
+                            'css_class': 'highlight',
+                            'linenums': False
+                        }
+                    }
+                )
     except Exception:
         pass
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,129 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <!-- Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js"></script>
+    <!-- Tailwind Typography Plugin -->
+    <script>
+        // 应用 Markdown 样式的函数
+        function applyMarkdownStyles() {
+            const readmeContent = document.getElementById('readme-content');
+            if (readmeContent) {
+                const h1Elements = readmeContent.querySelectorAll('h1');
+                const h2Elements = readmeContent.querySelectorAll('h2');
+                const h3Elements = readmeContent.querySelectorAll('h3');
+                const h4Elements = readmeContent.querySelectorAll('h4');
+                const pElements = readmeContent.querySelectorAll('p');
+                const ulElements = readmeContent.querySelectorAll('ul');
+                const olElements = readmeContent.querySelectorAll('ol');
+                const liElements = readmeContent.querySelectorAll('li');
+                const codeElements = readmeContent.querySelectorAll('code');
+                const preElements = readmeContent.querySelectorAll('pre');
+                const aElements = readmeContent.querySelectorAll('a');
+                const imgElements = readmeContent.querySelectorAll('img');
+                const blockquoteElements = readmeContent.querySelectorAll('blockquote');
+                const hrElements = readmeContent.querySelectorAll('hr');
+                const tableElements = readmeContent.querySelectorAll('table');
+                
+                h1Elements.forEach(el => {
+                    if (!el.className.includes('font-bold')) {
+                        el.className = 'text-4xl font-bold mt-8 mb-4 text-gray-900 dark:text-white border-b pb-3 border-gray-300 dark:border-gray-700';
+                    }
+                });
+                h2Elements.forEach(el => {
+                    if (!el.className.includes('font-bold')) {
+                        el.className = 'text-3xl font-bold mt-6 mb-3 text-gray-900 dark:text-white border-b pb-2 border-gray-300 dark:border-gray-700';
+                    }
+                });
+                h3Elements.forEach(el => {
+                    if (!el.className.includes('font-bold')) {
+                        el.className = 'text-2xl font-bold mt-5 mb-2 text-gray-900 dark:text-white';
+                    }
+                });
+                h4Elements.forEach(el => {
+                    if (!el.className.includes('font-bold')) {
+                        el.className = 'text-xl font-bold mt-4 mb-2 text-gray-900 dark:text-white';
+                    }
+                });
+                pElements.forEach(el => {
+                    if (!el.className.includes('text-gray')) {
+                        el.className = 'mb-4 text-gray-700 dark:text-gray-300 leading-relaxed';
+                    }
+                });
+                ulElements.forEach(el => {
+                    if (!el.className.includes('list-disc')) {
+                        el.className = 'list-disc list-inside mb-4 ml-4 text-gray-700 dark:text-gray-300 space-y-1';
+                    }
+                });
+                olElements.forEach(el => {
+                    if (!el.className.includes('list-decimal')) {
+                        el.className = 'list-decimal list-inside mb-4 ml-4 text-gray-700 dark:text-gray-300 space-y-1';
+                    }
+                });
+                liElements.forEach(el => {
+                    if (!el.className.includes('mb')) {
+                        el.className = 'mb-1';
+                    }
+                });
+                codeElements.forEach(el => {
+                    if (el.parentElement.tagName !== 'PRE' && !el.className.includes('bg-gray')) {
+                        el.className = 'bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded text-red-600 dark:text-red-400 font-mono text-sm break-words';
+                    }
+                });
+                preElements.forEach(el => {
+                    if (!el.className.includes('bg-gray-900')) {
+                        el.className = 'bg-gray-900 dark:bg-gray-950 text-gray-100 p-4 rounded-lg overflow-x-auto mb-4 text-sm';
+                    }
+                });
+                aElements.forEach(el => {
+                    if (!el.className.includes('text-blue')) {
+                        el.className = 'text-blue-600 dark:text-blue-400 hover:underline font-semibold';
+                    }
+                });
+                imgElements.forEach(el => {
+                    if (!el.className.includes('max-w-full')) {
+                        el.className = 'max-w-full h-auto rounded-lg my-4 shadow-lg';
+                    }
+                });
+                blockquoteElements.forEach(el => {
+                    if (!el.className.includes('border-l')) {
+                        el.className = 'border-l-4 border-gray-400 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 pl-4 py-2 my-4 text-gray-700 dark:text-gray-300 italic';
+                    }
+                });
+                hrElements.forEach(el => {
+                    if (!el.className.includes('border')) {
+                        el.className = 'my-6 border-t border-gray-300 dark:border-gray-700';
+                    }
+                });
+                tableElements.forEach(el => {
+                    if (!el.className.includes('min-w-full')) {
+                        el.className = 'min-w-full border-collapse border border-gray-300 dark:border-gray-700 my-4';
+                    }
+                });
+                
+                // 为 table 的 th 和 td 添加样式
+                const thElements = readmeContent.querySelectorAll('th');
+                const tdElements = readmeContent.querySelectorAll('td');
+                
+                thElements.forEach(el => {
+                    if (!el.className.includes('bg')) {
+                        el.className = 'bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 px-4 py-2 font-semibold text-gray-900 dark:text-white text-left';
+                    }
+                });
+                
+                tdElements.forEach(el => {
+                    if (!el.className.includes('border')) {
+                        el.className = 'border border-gray-300 dark:border-gray-700 px-4 py-2 text-gray-700 dark:text-gray-300';
+                    }
+                });
+            }
+        }
+        
+        // 在 DOM 加载完成后立即应用样式
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', applyMarkdownStyles);
+        } else {
+            applyMarkdownStyles();
+        }
+    </script>
     <!-- 配置 Tailwind -->
     <script>
         tailwind.config = {
@@ -367,7 +490,7 @@
                         <i class="fa-solid fa-file-lines text-primary dark:text-primary-dark mr-2"></i>
                         个人介绍
                     </h2>
-                    <div class="prose dark:prose-invert max-w-none" id="readme-content">
+                    <div class="max-w-none" id="readme-content">
                         {{ github_info.readme_content|safe }}
                     </div>
                 </div>


### PR DESCRIPTION
- 问题：有些md格式无法正确从GitHub首页抓取到本地
- 优化app.py中的Markdown转换，添加扩展支持(extra, codehilite, toc, tables)
- 改进templates/index.html前端样式，动态应用Tailwind CSS到Markdown元素

